### PR TITLE
add VS Code IDE DuckDB related tools to SQL Clients section (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@
 
 ## SQL Clients and IDE that Support DuckDB
 
+- [DuckDB SQL Tools](https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.duckdb-sql-tools) - Free DuckDB SQL Tools for VS Code IDE.
+- [DuckDB Pro Tools](https://github.com/RandomFractals/pro-data-tools/blob/main/duckdb-tools.md#duckdb-pro-tools) - Premium DuckDB Tools for VS Code IDE with advanced DuckDB connection features and extended database schema views.
 - [Harlequin](https://harlequin.sh) - The DuckDB IDE for your terminal. ([GitHub](https://github.com/tconbeer/harlequin)).
 - [qStudio](https://www.timestored.com/qstudio/) - A free SQL tool specialized for data analysts. It runs on every operating system and allows easy browsing of tables and charting of results.
+- [PRQL Pro Tools](https://github.com/RandomFractals/pro-data-tools/tree/main#prql-pro-tools) - Premium PRQL Tools for VS Code IDE with PRQL Run Query Code Lens and DuckDB SQL Tools support.
+- [Markdown SQL Pro Tools](https://github.com/RandomFractals/pro-data-tools/tree/main#markdown-sql-pro-tools) - Premium Markdown SQL Tools for VS Code IDE with SQL Code Lenses and DuckDB SQL Tools integration.
 
 ## Projects Powered by DuckDB
 
@@ -55,7 +59,7 @@
 
 ## Integrations
 
-- [dbt-duckdb](https://github.com/jwills/dbt-duckdb) - DuckDB dbt adapter. 
+- [dbt-duckdb](https://github.com/jwills/dbt-duckdb) - DuckDB dbt adapter.
 - [data load tool - DuckDB destination](https://dlthub.com/docs/dlt-ecosystem/destinations/duckdb) - Extract and load data from APIs to DuckDB using dlt.
 - [target-duckdb](https://hub.meltano.com/loaders/target-duckdb/) - Load data to DuckDB based on Singer spec.
 - [Airbyte DuckDB destination](https://docs.airbyte.com/integrations/destinations/duckdb/) - Load data to DuckDB with Airbyte.

--- a/README.md
+++ b/README.md
@@ -45,12 +45,9 @@
 
 ## SQL Clients and IDE that Support DuckDB
 
-- [DuckDB SQL Tools](https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.duckdb-sql-tools) - Free DuckDB SQL Tools for VS Code IDE.
-- [DuckDB Pro Tools](https://github.com/RandomFractals/pro-data-tools/blob/main/duckdb-tools.md#duckdb-pro-tools) - Premium DuckDB Tools for VS Code IDE with advanced DuckDB connection features and extended database schema views.
 - [Harlequin](https://harlequin.sh) - The DuckDB IDE for your terminal. ([GitHub](https://github.com/tconbeer/harlequin)).
 - [qStudio](https://www.timestored.com/qstudio/) - A free SQL tool specialized for data analysts. It runs on every operating system and allows easy browsing of tables and charting of results.
-- [PRQL Pro Tools](https://github.com/RandomFractals/pro-data-tools/tree/main#prql-pro-tools) - Premium PRQL Tools for VS Code IDE with PRQL Run Query Code Lens and DuckDB SQL Tools support.
-- [Markdown SQL Pro Tools](https://github.com/RandomFractals/pro-data-tools/tree/main#markdown-sql-pro-tools) - Premium Markdown SQL Tools for VS Code IDE with SQL Code Lenses and DuckDB SQL Tools integration.
+- [DuckDB SQL Tools](https://marketplace.visualstudio.com/items?itemName=RandomFractalsInc.duckdb-sql-tools) - Free DuckDB SQL Tools for VS Code IDE. [Premium version available](https://github.com/RandomFractals/pro-data-tools/blob/main/duckdb-tools.md#duckdb-pro-tools) with advanced features.
 
 ## Projects Powered by DuckDB
 


### PR DESCRIPTION
as described in https://github.com/davidgasquez/awesome-duckdb/issues/21.

Updated SQL Clients and IDE tools section in our fork for this PR to preview updated doc:

https://github.com/RandomFractals/awesome-duckdb#sql-clients-and-ide-that-support-duckdb

We've included our Premium Pro data tools extensions as well, as they provide direct integration with DuckDB SQL Tools in VS Code IDE for PRQL docs and various markdown documents some DuckDB users might be interested to explore.