### PR TITLE
LinkChecker: Ignore HTTP redirects

### DIFF
--- a/.github/linkchecker/linkchecker.conf
+++ b/.github/linkchecker/linkchecker.conf
@@ -6,3 +6,4 @@ sslverify=0
 
 [filtering]
 checkextern=1
+ignorewarnings=http-redirected


### PR DESCRIPTION
This should fix the CI, which is failing due to a change in LinkChecker that causes marks redirects as errors (and not warnings like it used to do): https://github.com/linkchecker/linkchecker/issues/762#issuecomment-1732482903