### PR TITLE
Add Evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - [Bauplan](https://www.bauplanlabs.com/) - A serverless data transformation platform for data lakes.
 - [Excalichart.com](http://www.excalichart.com/) - A fast, free dashboard for exploring your data.
 - [Malloy](https://www.malloydata.dev/) - Malloy is an experimental language for describing data relationships and transformations. Malloy connects to BigQuery and Postgres, and natively supports DuckDB.
+- [Evidence](https://evidence.dev) - Generate reports using SQL and markdown. The DuckDB connector allows querying across DuckDB, csv, parquet and json.
 
 ## Libraries Powered by DuckDB
 


### PR DESCRIPTION
Evidence supports DuckDB as one of it's native adapters, and is shipped as the demo.

Upcoming support for DuckDB WASM is going to be released soon - can be previewed in https://github.com/evidence-dev/template/tree/next