### PR TITLE
Added @jetblack/duckdb-react to the libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@
 - [Splink](http://github.com/moj-analytical-services/splink) - A free Python library for fast, accurate data deduplication and record linkage.
 - [Simple-data-analysis](https://github.com/nshiab/simple-data-analysis) - Easy-to-use and high-performance JavaScript library for data analysis.
 - [duckdb_fdw](https://github.com/alitrack/duckdb_fdw) - DuckDB Foreign Data Wrapper for PostgreSQL.
+- [@jetblack/duckdb-react](https://github.com/rob-blackbourn/jetblack-duckdb-react) - A context manager for React and duckdb-wasm.
 
 ## SQL Clients and IDE that Support DuckDB
 


### PR DESCRIPTION
This is a small library which makes it simple to use duckdb-wasm in a web client using React.

I wasn't too sure where to put it, but the "Libraries" section seemed the most appropriate.

The library is [@jetblack/duckdb-react](https://github.com/rob-blackbourn/jetblack-duckdb-react).