### PR TITLE
Adding pypi-duck-flow project

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [`endoflife.date` database](https://www.kaggle.com/datasets/adriensales/endoflife-date-database) - Daily dumps of endoflife.date data.
 - [`transfermarkt-datasets`](https://github.com/dcaribou/transfermarkt-datasets) - Curated football datasets from [Transfermarkt](https://www.transfermarkt.co.uk/).
 - [duckDB-embedding-search](https://github.com/patricktrainer/duckdb-embedding-search) - A search engine for DuckDB that uses embedding vectors to find similar documents.
+- [DuckDB PyPI stats live dashboard](https://github.com/mehd-io/pypi-duck-flow) - Live dashboard of PyPI downloads using DuckDB, dbt, Evidence and MotherDuck with code source to build your own.
 
 ## Integrations
 


### PR DESCRIPTION
Hey there 👋

I think it would be great to highlight the project I've done, as it covers a lot about DuckDB and includes production-ready pipelines for anyone to replicate and build their own dashboard to track PyPI download stats.

Check out the demo here: https://duckdbstats.com/