### PR TITLE
Update README with link to whereabouts library in tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [ParadeDB](https://github.com/paradedb/paradedb) - Postgres for Search and Analytics, powered by DuckDB-embedded-in-Postgres.
 - [Crunchy Bridge for Analytics](https://www.crunchydata.com/products/crunchy-bridge-for-analytics) - Fully managed DBaaS based in Postgres integrated with DuckDB.
 - [UniverSQL](https://github.com/buremba/universql) - An implementation of Snowflake API, enables running queries on Snowflake tables locally with DuckDB without a running warehouse.
+- [Whereabouts](https://github.com/ajl2718/whereabouts) - Fast, accurate, open-source geocoding in Python, using DuckDB.
 
 ### Web Clients
 


### PR DESCRIPTION
I have created an open source Python project for geocoding address data. The core geocoding algorithms are implemented in SQL using DuckDB and the package can be installed using two lines of code, without requiring server setup (thanks to DuckDB). I would like to share this further with the community as I believe it is a useful tool.