### PR TITLE
Add Termux package

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [SQL DATA LENS](https://sqldatalens.com/build-in-support-for-duckdb/) - A lightweight, commercial SQL IDE that supports different DBMS, including DuckDB. The focus on performance and special DBMS features.
 - [Dataflare](https://dataflare.app) - Simple easy-to-use database manager, supports DuckDB, PostgreSQL, MySQL, SQL Server, SQLite etc.
 - [manifold-sql (DuckDB for Java)](https://github.com/manifold-systems/manifold/blob/master/docs/articles/duckdb_info.md) - Use native DuckDB SQL of any complexity directly & type-safely in Java source with comprehensive IntelliJ support.
+- [Termux DuckB package)](https://packages.termux.dev/apt/termux-main/pool/main/libd/libduckdb/) - DuckDB CLI client for the Termux Android terminal emulator.
 
 ## Projects Powered by DuckDB
 


### PR DESCRIPTION
The DuckDB CLI application runs on [Termux](https://termux.dev/en/), adding this to the repo.