### PR TITLE
Mention Ontop

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [metabase_duckdb_driver](https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver) - Metabase DuckDB Driver shipped as 3rd party plugin.
 - [xlDuckDb](https://github.com/RusselWebber/xlDuckDb) - Excel addin to run DuckDB queries in Excel.
 - [Hasura DuckDB Connector](https://github.com/hasura/ndc-duckdb) - Allows connecting to a DuckDB database or a MotherDuck hosted DuckDB database through a GraphQL API.
-- [Ontop](https://ontop-vkg.org/guide/databases/duckdb.html) - Allows to create Virtual Knowledge Graphs directly from DuckDB 
+- [Ontop](https://ontop-vkg.org/guide/databases/duckdb.html) - Allows to create Virtual Knowledge Graphs directly from DuckDB.
 
 ## Client-Server Setups
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [metabase_duckdb_driver](https://github.com/MotherDuck-Open-Source/metabase_duckdb_driver) - Metabase DuckDB Driver shipped as 3rd party plugin.
 - [xlDuckDb](https://github.com/RusselWebber/xlDuckDb) - Excel addin to run DuckDB queries in Excel.
 - [Hasura DuckDB Connector](https://github.com/hasura/ndc-duckdb) - Allows connecting to a DuckDB database or a MotherDuck hosted DuckDB database through a GraphQL API.
+- [Ontop](https://ontop-vkg.org/guide/databases/duckdb.html) - Allows to create Virtual Knowledge Graphs directly from DuckDB 
 
 ## Client-Server Setups
 


### PR DESCRIPTION
Support for DuckDB was added in version Ontop 5.0.2 (https://ontop-vkg.org/guide/releases.html#_5-0-2-march-9-2023).

The combination raised quite some interest, see, e.g. https://www.linkedin.com/pulse/scaling-sparql-querying-billion-observations-ontop-duckdb-gschwend-myghf/.
I described the use of DuckDB for quickly creating Knowledge Graphs from Parquet files with DuckDB: https://ontopic.ai/en/tech-notes/create-virtual-knowledge-graphs-from-parquet-files/.