### PR TITLE
Added Kepler.gl

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [SQLMesh](https://github.com/TobikoData/sqlmesh) - A next-generation data transformation and modeling framework with support for DuckDB connections for state, transformations & running unit tests locally.
 - [ADPivot](https://github.com/danilo-css/analytics-data-pivot) - No code tool built on top of DuckDB-Wasm and Pyodide that helps build pivot tables from databases of any size with a few clicks.
 - [Duck-UI](https://demo.duckui.com/) - Duck-UI is a web-based interface for interacting with DuckDB with a SQL editor, data import/export, data explorer, query history, theme toggle and keyboard shortcuts.
+- [Kepler.gl](https://kepler.gl/) - Kepler.gl is a powerful open source geospatial analysis tool for large-scale data sets, now embeds duckdb wasm to create geospatial layers.
 
 ### Web Clients (WebAssembly)
 


### PR DESCRIPTION
Foursquare's initiative of adding a duckdb console to Kepler.gl seems to work great and it is now accessible directly from the main version.