### PR TITLE
Add cache httpfs to community extension list

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Official DuckDB extensions, which can installed via `INSTALL ⟨extension_name�
 Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨extension_name⟩ FROM community`.
 
 - [`bigquery`](https://github.com/hafenkran/duckdb-bigquery) - Integrates DuckDB with Google BigQuery, allowing direct querying and management of BigQuery datasets.
+- [`cache_httpfs`](https://github.com/dentiny/duck-read-cache-fs) - Adds a read caching layer to duckdb filesystem to improve query performance and reduce egress cost.
 - [`chsql`](https://github.com/lmangani/duckdb-extension-clickhouse-sql) - ClickHouse SQL Dialect macros for DuckDB.
 - [`crypto`](https://github.com/rustyconover/duckdb-crypto-extension) - Cryptographic hash functions and HMAC.
 - [`duckpgq`](https://github.com/cwida/duckpgq-extension) - Add supports for SQL/PGQ (Property Graph Queries) introduced in the SQL:2023 standard.


### PR DESCRIPTION
This is the author of cache httpfs duckdb community extension, would like to add our extension to the curated list.
Extension link: https://duckdb.org/community_extensions/extensions/cache_httpfs.html