### PR TITLE
Added duckdb.yazi to the end of tools powered by duckdb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [SQLMesh](https://github.com/TobikoData/sqlmesh) - A next-generation data transformation and modeling framework with support for DuckDB connections for state, transformations & running unit tests locally.
 - [ADPivot](https://github.com/danilo-css/analytics-data-pivot) - No code tool built on top of DuckDB-Wasm and Pyodide that helps build pivot tables from databases of any size with a few clicks.
 - [Kepler.gl](https://kepler.gl/) - Kepler.gl is a powerful open source geospatial analysis tool for large-scale data sets, now embeds duckdb wasm to create geospatial layers.
+- [duckdb.yazi](https://github.com/wylie102/duckdb.yazi) - Preview csv/tsv, json, and Parquet files in the yazi file manager using duckdb. View the raw data, or a "summarized" view with data-types, min, max, avg etc. for all columns.
 
 ## Backends
 


### PR DESCRIPTION
Adds [duckdb.yazi](https://github.com/wylie102/duckdb.yazi) to the end of tools powered by duckdb.

It's a plugin for  [yazi](https://github.com/sxyazi/yazi), a terminal based file manager, that lets you view csv, tsv, json and parquet files just by scrolling over them. It uses duckdb, and you can view either a standard view or a view of the output if you ran "summarized" on the file. These views are all cached in individual duckdb databases.

It's not on the ETL level of some of the other tools but hopefully some will find it useful for getting a view of any data files they are using directly, without having to load and query them.

I didn't link to yazi in the description as it itself does not use duckdb and I didn't know if you might have issues with that, but I can add the link if you would like.

