### PR TITLE
Add PyStack't to Projects Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ You can chat with this page's content on [HuggingChat](https://hf.co/chat/assist
 - [`transfermarkt-datasets`](https://github.com/dcaribou/transfermarkt-datasets) - Curated football datasets from [Transfermarkt](https://www.transfermarkt.co.uk/).
 - [duckdb-embedding-search](https://github.com/patricktrainer/duckdb-embedding-search) - A search engine for DuckDB that uses embedding vectors to find similar documents.
 - [DuckDB PyPI stats live dashboard](https://duckdbstats.com/) - Live dashboard of PyPI downloads using DuckDB, dbt, Evidence and MotherDuck with code source to build your own.
+- [PyStack't](https://github.com/LienBosmans/pystackt) - Python package that supports data preparation for object-centric process mining
 
 ## Integrations
 


### PR DESCRIPTION
Not sure if my project is big enough to be added to this awesome DuckDB list, but if you don't ask the answer is always no, right? 😄 

PyStack't is a Python package that heavily relies on DuckDB to support data activities related to object-centric process mining.
- Data extraction: pulls activity data from GitHub repo and stores it as object-centric event data (OCED) in DuckDB database file
- Data export: does all necessary data transformation in DuckDB and then uses SQLite *(OCEL 2.0)* and CSV *(PromG)* compatibility to export to export the data to different OCED formats
- Data exploration: Creates database views in DuckDB file *(summary statistics)*.  Does preprocessing of OCED data in DuckDB and then connects DuckDB to Dash/Plotly application *(interactive graph visualizations)*.

![pystackt_architecture](https://github.com/user-attachments/assets/090d802d-adc0-40e1-a8a3-9c7ac5b98c8d)
