### PR TITLE
Add pfc: block-indexed JSONL log compression extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨
 - [`lindel`](https://github.com/rustyconover/duckdb-lindel-extension) - Linearization/Delinearization, Z-Order, Hilbert and Morton Curves.
 - [`netquack`](https://github.com/hatamiarash7/duckdb-netquack) - Parsing, extracting, and analyzing domains, URIs, and paths with ease.
 - [`observefs`](https://github.com/dentiny/duckdb-filesystem-observability) - I/O observability for DuckDB filesystems with latency statistics and external file cache access insights.
+- [`pfc`](https://github.com/ImpossibleForge/pfc-duckdb) - Read block-indexed PFC-compressed JSONL logs with timestamp filtering — 25% smaller than gzip with minimal S3 egress.
 - [`prql`](https://github.com/ywelsch/duckdb-prql) - Run PRQL commands directly within DuckDB.
 - [`scrooge`](https://github.com/pdet/Scrooge-McDuck) - A set of aggregation functions and data scanners on financial data.
 - [`shellfs`](https://github.com/rustyconover/duckdb-shellfs-extension) - Allows shell commands to be used for input and output.


### PR DESCRIPTION
## What is this?

[`pfc`](https://github.com/ImpossibleForge/pfc-duckdb) is a DuckDB Community Extension that reads PFC-compressed JSONL log archives with block-level timestamp indexing.

Install it via:
```sql
INSTALL pfc FROM community;
LOAD pfc;

SELECT level, message
FROM read_pfc_jsonl('s3://my-bucket/logs/2026-01-01.pfc')
WHERE ts >= 1735686000 AND ts < 1735689600;
```

## Why add it?

- **25% smaller than gzip** for JSONL logs (~9% of original size)
- **Block-level timestamp index** — only decompress the blocks you need
- **Official DuckDB Community Hub listing** — `INSTALL pfc FROM community` works today
- **Zero egress for migrations** — [pfc-migrate](https://github.com/ImpossibleForge/pfc-migrate) converts existing S3/Azure/GCS archives in-region

## Checklist

- [x] Link is to a stable, working repo
- [x] Extension is published on DuckDB Community Hub
- [x] Entry is alphabetically sorted (between `observefs` and `prql`)
- [x] Description is concise and accurate