### PR TITLE
Add stratif.io to Tools Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [connections.duckdb](https://github.com/tomjakubowski/connections.duckdb) - Play the New York Times Connections Puzzle with DuckDB.
 - [ReportBurster](https://github.com/flowkraft/reportburster) - Business Intelligence Done Right - ReportBurster uses DuckDB as its in-process analytics database engine, and for larger workloads, supports ClickHouse too.
 - [DataSpoc Lens](https://github.com/dataspoclab/dataspoc-lens) - Virtual warehouse over cloud Parquet. SQL shell, Jupyter/Marimo notebooks, AI natural language queries, and local cache — all powered by DuckDB.
+- [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and paths on DuckDB (and Postgres, Snowflake, ClickHouse, Databricks).
 
 ## Backends
 


### PR DESCRIPTION
Adds stratif.io under Tools Powered by DuckDB.

stratif.io is an open-source (Apache-2.0), self-hosted product analytics tool. DuckDB is a first-class backend — point it at a DuckDB database and run funnels, retention, and path analysis without moving data out.

Repo: https://github.com/stratif-io/stratif.io