### PR TITLE
Add rawquery to Client-Server Setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Termux DuckDB package](https://packages.termux.dev/apt/termux-main/pool/main/libd/libduckdb/) - DuckDB CLI client for the Termux Android terminal emulator.
 - [pg_lake](https://github.com/snowflake-labs/pg_lake) - `pg_lake` integrates Iceberg and data lake files into Postgres. Uses DuckDB to execute queries.
 - [AliSQL](https://github.com/alibaba/AliSQL) - A MySQL branch originated from Alibaba Group. Integrates DuckDB as a native storage engine.
+- [rawquery](https://rawquery.dev) - Managed analytical platform pairing DuckDB compute with Iceberg storage on S3. Postgres wire protocol, CLI, and Python API.
 
 ## Extensions
 


### PR DESCRIPTION
Adds rawquery under Client-Server Setups.

[rawquery](https://rawquery.dev) is a managed analytical data platform. DuckDB is the query engine — the worker pool runs DuckDB instances against Iceberg tables stored on S3. Clients connect via the Postgres wire protocol, the `rq` CLI, or a Python/REST API.

Docs: https://rawquery.dev/docs