### PR TITLE
Add Enrich.sh - event ingestion with DuckDB-queryable Parquet output as 277

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Kotlin DataFrame](https://kotlin.github.io/dataframe/duckdb.html) - Supports reading from DuckDB databases using JDBC.
 - [Sidemantic](https://github.com/sidequery/sidemantic) - A semantic layer with DuckDB integration.
 - [Cloudflare R2 Data Catalog connector](https://developers.cloudflare.com/r2/data-catalog/config-examples/duckdb/) - Connect to Cloudflare R2 Data Catalog with DuckDB.
+- [Enrich.sh](https://enrich.sh) - Lightweight event ingestion that stores JSON events as Parquet in R2, queryable directly from DuckDB.
 
 ## Client-Server Setups
 


### PR DESCRIPTION
https://docs.enrich.sh/getting-started.html#using-duckdb 

Enrich.sh ingests JSON events through a REST API and writes them as Hive-partitioned Parquet files to Cloudflare R2, designed to be queried directly from DuckDB via httpfs without a broker, warehouse, or pipeline in between. It fits the Tools section alongside entries like Boilstream and Serverless DuckDB over S3, since DuckDB is the primary query layer the product is built around. Auto-added geo/IP/ISP columns and time-based partitioning let DuckDB prune row groups efficiently on filtered queries, which is the pattern several existing entries on this list already showcase.