### PR TITLE
Add OrionBelt Semantic Layer to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,10 +275,10 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [duckdb-teradata](https://github.com/duckdb/duckdb-teradata) - Teradata connector.
 - [Kotlin DataFrame](https://kotlin.github.io/dataframe/duckdb.html) - Supports reading from DuckDB databases using JDBC.
 - [Sidemantic](https://github.com/sidequery/sidemantic) - A semantic layer with DuckDB integration.
-- [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML semantic models to optimized SQL across 8 engines including DuckDB. Ships with an `ob-duckdb` driver, REST + Arrow Flight SQL + Postgres wire surfaces, and a baked-in DuckDB quickstart on Colab.
 - [Cloudflare R2 Data Catalog connector](https://developers.cloudflare.com/r2/data-catalog/config-examples/duckdb/) - Connect to Cloudflare R2 Data Catalog with DuckDB.
 - [Enrich.sh](https://enrich.sh) - Lightweight event ingestion that stores JSON events as Parquet in R2, queryable directly from DuckDB.
 - [DuckDB VBA](https://github.com/EtienneLenoir/duckdb-vba) - Excel/VBA integration for DuckDB using the native C API through a lightweight DLL bridge. Supports Range/Array ingestion, dictionary lookups, Parquet/CSV/JSON workflows, SQLite/PostgreSQL connectivity, and Access-to-DuckDB migration.
+- [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML semantic models to optimized SQL across 8 engines including DuckDB. Ships with an `ob-duckdb` driver, REST + Arrow Flight SQL + Postgres wire surfaces, and a baked-in DuckDB quickstart on Colab.
 
 ## Client-Server Setups
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [duckdb-teradata](https://github.com/duckdb/duckdb-teradata) - Teradata connector.
 - [Kotlin DataFrame](https://kotlin.github.io/dataframe/duckdb.html) - Supports reading from DuckDB databases using JDBC.
 - [Sidemantic](https://github.com/sidequery/sidemantic) - A semantic layer with DuckDB integration.
+- [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML semantic models to optimized SQL across 8 engines including DuckDB. Ships with an `ob-duckdb` driver, REST + Arrow Flight SQL + Postgres wire surfaces, and a baked-in DuckDB quickstart on Colab.
 - [Cloudflare R2 Data Catalog connector](https://developers.cloudflare.com/r2/data-catalog/config-examples/duckdb/) - Connect to Cloudflare R2 Data Catalog with DuckDB.
 - [Enrich.sh](https://enrich.sh) - Lightweight event ingestion that stores JSON events as Parquet in R2, queryable directly from DuckDB.
 - [DuckDB VBA](https://github.com/EtienneLenoir/duckdb-vba) - Excel/VBA integration for DuckDB using the native C API through a lightweight DLL bridge. Supports Range/Array ingestion, dictionary lookups, Parquet/CSV/JSON workflows, SQLite/PostgreSQL connectivity, and Access-to-DuckDB migration.


### PR DESCRIPTION
Adds [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) (OBSL) to the **Integrations** section.

## What it is

OBSL is an open-source semantic sidecar: define dimensions, measures, metrics, business rules in declarative YAML; compile them to optimized SQL across 8 engines (BigQuery, ClickHouse, Databricks, Dremio, **DuckDB**, MySQL, PostgreSQL, Snowflake) and execute via a REST API, Arrow Flight SQL, or Postgres wire protocol.

## DuckDB-specific story

- **`ob-duckdb` DB-API 2.0 driver** ships in the same monorepo / PyPI account (`ralforion`).
- The baked-in **Cloud Run demo** at https://orionbelt.ralforion.com runs entirely on DuckDB (no external warehouse required).
- The **Colab quickstart** (`examples/quickstart_colab.ipynb`) generates a TPC-H benchmark database with DuckDB and exercises every OBSL feature against it (no setup needed beyond opening the badge).
- DuckDB is exercised in CI by Tier 1 / Tier 2 correctness + drift snapshots for every release.

## Position in the list

Placed right after Sidemantic (the only other semantic layer in the Integrations section) for thematic grouping. The list isn't strictly alphabetical so adjacency on topic feels right; happy to move it if you prefer a different position.

## Project status

- Active (v2.7.6 released today).
- BSL-1.1 licensed.
- 2300+ tests, full CI.
- Live demo + docs site + PyPI + Docker Hub + MCP server.