### PR TITLE
Add DuckQuery under Web Clients (WebAssembly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Joinery](https://github.com/joinery-labs/joinery) - Privacy-first local data analytics with a modern SQL editor, multi-format support (CSV, Excel, JSON, Parquet), and parameterized saved queries. Available as browser app and Tauri desktop client.
 - [DuckQuery](https://github.com/Chenkeliang/duckdb-query) - Open-source visual SQL workbench to query local files (CSV/Excel/Parquet/JSON) and remote databases (MySQL/PostgreSQL) in one cross-source JOIN, plus AI text-to-SQL. Browser demo runs on DuckDB-Wasm; the full version self-hosts via Docker.
 
-
 ## SQL Clients and IDE that Support DuckDB
 
 - [Harlequin](https://harlequin.sh) - The DuckDB IDE (TUI) for your terminal.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [TabulaStudio](https://tabulastudio.com) - Browser-only enterprise data analytics platform with Jupyter-style notebooks, AI-powered visualizations, and enterprise performance (10M+ rows/second). Direct access to files and live databases like (Neon and Supabase ) without servers, cloud uploads, or setup—your data never leaves your browser.
 - [dbxlite](https://dbxlite.com/) - DuckDB workbench for native & browser.
 - [Joinery](https://github.com/joinery-labs/joinery) - Privacy-first local data analytics with a modern SQL editor, multi-format support (CSV, Excel, JSON, Parquet), and parameterized saved queries. Available as browser app and Tauri desktop client.
+- [DuckQuery](https://github.com/Chenkeliang/duckdb-query) - Open-source visual SQL workbench to query local files (CSV/Excel/Parquet/JSON) and remote databases (MySQL/PostgreSQL) in one cross-source JOIN, plus AI text-to-SQL. Browser demo runs on DuckDB-Wasm; the full version self-hosts via Docker.
+
 
 ## SQL Clients and IDE that Support DuckDB
 


### PR DESCRIPTION
Adds DuckQuery under "DuckDB Clients and UIs → Web Clients (WebAssembly)".

DuckQuery is an open-source visual SQL workbench built on DuckDB. It queries
local files (CSV/Excel/Parquet/JSON) and remote databases (MySQL/PostgreSQL)
and JOINs them in a single SQL statement — files load as native DuckDB tables,
external databases connect via DuckDB's ATTACH. It also has AI text-to-SQL
(drafts SQL you confirm before running, never auto-executed).

The demo runs entirely in-browser on DuckDB-Wasm; the full version (federated
MySQL/PostgreSQL + AI) self-hosts via Docker. Fits alongside peers like Duck-UI
and PondPilot in this section.

Repo: https://github.com/Chenkeliang/duckdb-query
Demo: https://chenkeliang.github.io/duckdb-query/
License: MIT
