### PR TITLE
Add Duckle to Tools Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [DataSpoc Lens](https://github.com/dataspoclab/dataspoc-lens) - Virtual warehouse over cloud Parquet. SQL shell, Jupyter/Marimo notebooks, AI natural language queries, and local cache — all powered by DuckDB.
 - [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and paths on DuckDB (and Postgres, Snowflake, ClickHouse, Databricks).
 - [DBConvert Streams](https://streams.dbconvert.com/) - Database IDE and migration tool with DuckDB-powered federated SQL.
+- [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first visual ETL/ELT studio. Drag sources, transforms and sinks onto a canvas; it compiles to plain DuckDB SQL and runs entirely on DuckDB. Open source desktop app, with a built-in MCP server for generating and running pipelines from natural language.
 
 ## Backends
 


### PR DESCRIPTION
Adds [Duckle](https://github.com/SouravRoy-ETL/duckle) under **Tools Powered by DuckDB**.

Duckle is an open-source, local-first visual ETL/ELT studio that runs entirely on DuckDB: you drag sources, transforms and sinks onto a canvas and it compiles to plain DuckDB SQL. It sits alongside existing entries like Amphi ETL, ETLX and Enso Analytics.

Open source (Apache-2.0 / MIT), desktop app, 300+ connectors, with a built-in MCP server.