### PR TITLE
Add HitKeep

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [stratif.io](https://stratif.io) - Open-source, self-hosted, warehouse-native product analytics. Runs funnels, retention, and paths on DuckDB (and Postgres, Snowflake, ClickHouse, Databricks).
 - [DBConvert Streams](https://streams.dbconvert.com/) - Database IDE and migration tool with DuckDB-powered federated SQL.
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first visual ETL/ELT studio. Drag sources, transforms and sinks onto a canvas; it compiles to plain DuckDB SQL and runs entirely on DuckDB. Open source desktop app, with a built-in MCP server for generating and running pipelines from natural language.
+- [HitKeep](https://github.com/PascaleBeier/hitkeep) - Open-source, privacy-first web analytics for traffic, funnels, ecommerce, Search Console, and AI visibility. Runs as a single Go binary with embedded DuckDB.
 
 ## Backends
 


### PR DESCRIPTION
## Summary

Adds HitKeep to the Tools Powered by DuckDB section.

HitKeep is an open-source, privacy-first web analytics tool that runs as a single Go binary with embedded DuckDB. I placed it near similar analytics tools in the list.

## Validation

- Confirmed the README contains one HitKeep entry.
- Confirmed the HitKeep GitHub link resolves successfully.
- Reviewed the Markdown diff for formatting consistency.
