### PR TITLE
Update Bonnard entry to current positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Enso Analytics](https://www.ensoanalytics.com/) - Dual visual/textual programming language and analytics platform, allowing DuckDB to be used as a data engine for its visual analytics and low-code workflows.
 - [OpenSheet](https://opensheet.app) - Spreadsheet-style data tool with visual canvas, inline editing, and AI commands for SQL transformations.
 - [Excellent Bi](https://trobee.one/ebi/) - Duck Powered simple analysis and business intelligence dashboard.  Load excel, csv, parquet files, instantly query your data in the query analyzer tool, make multiple simple dashboards.  Data stays local in OPFS local browser storage which is native to Edge and Chrome.
-- [Bonnard](https://bonnard.dev) - Open-source agentic schema for reliable data outputs. Uses DuckDB as a local development warehouse with MCP server for agent connectivity.
+- [Bonnard](https://bonnard.dev) - Governed, multi-tenant MCP access to customer data. Connects DuckDB (and Snowflake, BigQuery, Postgres) to AI agents as a secure, per-customer MCP server.
 - [connections.duckdb](https://github.com/tomjakubowski/connections.duckdb) - Play the New York Times Connections Puzzle with DuckDB.
 - [ReportBurster](https://github.com/flowkraft/reportburster) - Business Intelligence Done Right - ReportBurster uses DuckDB as its in-process analytics database engine, and for larger workloads, supports ClickHouse too.
 - [DataSpoc Lens](https://github.com/dataspoclab/dataspoc-lens) - Virtual warehouse over cloud Parquet. SQL shell, Jupyter/Marimo notebooks, AI natural language queries, and local cache — all powered by DuckDB.


### PR DESCRIPTION
Refreshes the Bonnard entry to its current positioning: governed, multi-tenant MCP access to customer data, with DuckDB as a supported source. Single-line change.