### PR TITLE
Add stats_duck, Bedevere, and KoliLang

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Duckle](https://github.com/SouravRoy-ETL/duckle) - Local-first visual ETL/ELT studio. Drag sources, transforms and sinks onto a canvas; it compiles to plain DuckDB SQL and runs entirely on DuckDB. Open source desktop app, with a built-in MCP server for generating and running pipelines from natural language.
 - [HitKeep](https://github.com/PascaleBeier/hitkeep) - Open-source, privacy-first web analytics for traffic, funnels, ecommerce, Search Console, and AI visibility. Runs as a single Go binary with embedded DuckDB.
 - [AnkaFlow](https://github.com/targetta/ankaflow) - YAML-based data pipeline framework that runs both locally and fully in-browser designed for data engineers, ML teams, and SaaS developers who need flexible, SQL-powered pipelines.
+- [KoliLang](https://editor.kolistat.com) - A SAS language engine (DATA step, macros, PROCs) that translates programs to DuckDB SQL — runs natively or fully in the browser on DuckDB-Wasm.
 
 ## Backends
 
@@ -220,6 +221,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [DuckQuery](https://github.com/Chenkeliang/duckdb-query) - Open-source visual SQL workbench to query local files (CSV/Excel/Parquet/JSON) and remote databases (MySQL/PostgreSQL) in one cross-source JOIN, plus AI text-to-SQL. Browser demo runs on DuckDB-Wasm; the full version self-hosts via Docker.
 - [csvtodashboard](https://csvtodashboard.com/csv-sql-query) - Free SQL-on-CSV in the browser via DuckDB-Wasm — no signup, no upload, files stay on-device.
 - [ParquetKit](https://parquetkit.com) - Browser-based Parquet viewer, SQL workbench and converter powered by DuckDB-Wasm. Fully client-side — files never leave your device.
+- [Bedevere](https://bedeverewise.app) - Tabular data visualizer and DuckDB SQL editor on DuckDB-Wasm: open CSV/Parquet/JSON/Arrow locally, chart results with a grammar-of-graphics `VISUALIZE` syntax, and embed it anywhere via npm component or a one-line iframe.
 
 ## SQL Clients and IDE that Support DuckDB
 
@@ -353,6 +355,7 @@ Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨
 - [`prql`](https://github.com/ywelsch/duckdb-prql) - Run PRQL commands directly within DuckDB.
 - [`scrooge`](https://github.com/pdet/Scrooge-McDuck) - A set of aggregation functions and data scanners on financial data.
 - [`shellfs`](https://github.com/rustyconover/duckdb-shellfs-extension) - Allows shell commands to be used for input and output.
+- [`stats_duck`](https://github.com/KoliStat/the-stats-duck) - Statistics for tabular and clinical data: descriptive tables (`table_one`), linear models with robust/clustered standard errors, meta-analysis, bootstrap, and a grammar-of-graphics `VISUALIZE` clause that turns queries into Vega-Lite charts.
 - [`ulid`](https://github.com/Maxxen/duckdb_ulid) - ULID data type for DuckDB. A ULID is similar to a UUID except that it also contains a timestamp component.
 - [`yardstick`](https://github.com/sidequery/yardstick) - Implements Measures in SQL paper as a DuckDB extension for centralized metric definitions / en embedded semantic layer.
 - [`infera`](https://github.com/CogitatorTech/infera) - A DuckDB extension for in-database inference.


### PR DESCRIPTION
Three DuckDB-based projects from KoliStat (disclosure: mine):

- **`stats_duck`** → Community Extensions: a statistics extension on the [community repo](https://duckdb.org/community_extensions/extensions/stats_duck): lots of statistical tests and distributions, linear models with robust/clustered SEs, bootstrap, and a grammar-of-graphics `VISUALIZE` clause returning Vega-Lite specs.
- **Bedevere** → Web Clients (WebAssembly): a DuckDB-Wasm data visualizer/SQL editor ([bedeverewise.app](https://bedeverewise.app)), embeddable via npm or iframe. A desktop app for Windows is also available in beta release.
- **KoliLang** → Tools Powered by DuckDB: a SAS language engine that translates DATA steps/PROCs to DuckDB SQL, running natively or in the browser ([editor.kolistat.com](https://editor.kolistat.com)).

Placed `stats_duck` alphabetically; the other two sections append.