### PR TITLE
Add DuckDB.EFCoreProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Omilayers](https://github.com/dkioroglou/omilayers) - A Python library for efficient data management that wraps the APIs of SQLite and DuckDB and offers a high-level interface analytical tasks that involve fast storage, processing and retrieval of data.
 - [Unleasharp.DB.DuckDB](https://github.com/TraberSoftware/Unleasharp.DB.DuckDB) - Lightweight DuckDB query-building client for C#.
 - [Snowflake Emulator](https://github.com/nnnkkk7/snowflake-emulator) - A lightweight Snowflake emulator built with Go and DuckDB for local development and testing.
+- [DuckDB.EFCoreProvider](https://github.com/skuirrels/DuckDB.EFCoreProvider) - Entity Framework Core provider for DuckDB and DuckLake, with LINQ, writes, migrations, bulk ingestion, and Parquet-backed tiered storage for .NET.
 
 ## DuckDB Clients and UIs
 


### PR DESCRIPTION
Adds DuckDB.EFCoreProvider, an EF Core 10 provider for DuckDB and DuckLake (MIT).