### PR TITLE
Add aws layer duckdb python

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Serverless DuckDB over S3](https://github.com/BauplanLabs/quack-reduce/) - Running DuckDB over a data lake on S3 using lambda.
 - [DuckDB snippets](https://duckdbsnippets.com/) - Collection of snippets curated by MotherDuck.
 - [DuckDB tldr page](https://tldr.inbrowser.app/pages/common/duckdb) - DuckDB's entry in [tldr pages](https://tldr.sh/), available in CLI via the `tldr duckdb` command.
-- [DuckDB AWS Lambda layer](https://github.com/tobilg/duckdb-nodejs-layer) - Run DuckDB in AWS Lambda functions.
+- [DuckDB AWS Lambda layer (Node.js)](https://github.com/tobilg/duckdb-nodejs-layer) - Run DuckDB in AWS Lambda functions.
 - [DuckDB AWS Lambda layer (Python)](https://github.com/bengeois/aws-layer-duckdb-python) - Run DuckDB in AWS Lambda functions using Python.
 - [Compatible DuckDB extensions for AWS Lambda](https://extensions.quacking.cloud/) - Extensions specifically compiled for the AWS Lambda runtime (GLIBC 2.26).
 - [Serverless DuckDB as API](https://github.com/tobilg/serverless-duckdb) - Use DuckDB as API with Amazon API Gateway and AWS Lambda.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [DuckDB snippets](https://duckdbsnippets.com/) - Collection of snippets curated by MotherDuck.
 - [DuckDB tldr page](https://tldr.inbrowser.app/pages/common/duckdb) - DuckDB's entry in [tldr pages](https://tldr.sh/), available in CLI via the `tldr duckdb` command.
 - [DuckDB AWS Lambda layer](https://github.com/tobilg/duckdb-nodejs-layer) - Run DuckDB in AWS Lambda functions.
+- [DuckDB AWS Lambda layer (Python)](https://github.com/bengeois/aws-layer-duckdb-python) - Run DuckDB in AWS Lambda functions using Python.
 - [Compatible DuckDB extensions for AWS Lambda](https://extensions.quacking.cloud/) - Extensions specifically compiled for the AWS Lambda runtime (GLIBC 2.26).
 - [Serverless DuckDB as API](https://github.com/tobilg/serverless-duckdb) - Use DuckDB as API with Amazon API Gateway and AWS Lambda.
 - [Serverless Parquet Repartitioner](https://github.com/tobilg/serverless-parquet-repartitioner) - Use DuckDB to repartition data in S3-based Data Lakes.


### PR DESCRIPTION
Adds the Python equivalent of the existing Node.js AWS Lambda layer. Also clarifies the existing entry with "_(Node.js)_" for disambiguation.