### PR TITLE
Add DataCharter to Tools Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [HitKeep](https://github.com/PascaleBeier/hitkeep) - Open-source, privacy-first web analytics for traffic, funnels, ecommerce, Search Console, and AI visibility. Runs as a single Go binary with embedded DuckDB.
 - [AnkaFlow](https://github.com/targetta/ankaflow) - YAML-based data pipeline framework that runs both locally and fully in-browser designed for data engineers, ML teams, and SaaS developers who need flexible, SQL-powered pipelines.
 - [KoliLang](https://editor.kolistat.com) - A SAS language engine (DATA step, macros, PROCs) that translates programs to DuckDB SQL — runs natively or fully in the browser on DuckDB-Wasm.
+- [DataCharter](https://github.com/datacharter/datacharter) - Local, contract-governed data explorer. Federates files and databases (Postgres, Snowflake, BigQuery, Excel, and more) through DuckDB — SQL editor, charts, profiling — then hands AI agents a PII-masked, read-only query surface over MCP. Apache-2.0.
 
 ## Backends
 


### PR DESCRIPTION
Adds [DataCharter](https://github.com/datacharter/datacharter) under **Tools Powered by DuckDB**.

DataCharter is a local, contract-governed data explorer built on DuckDB. It federates files and databases (Postgres, MySQL, SQLite, Snowflake, BigQuery, Excel, and more) through DuckDB with predicate/projection pushdown, adds a SQL editor, charts, and profiling, and hands AI agents a PII-masked, read-only query surface over MCP. Apache-2.0, installable via `uvx datacharter`.

One entry, appended to the end of the category.