### PR TITLE
Add Pondview

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [AnkaFlow](https://github.com/targetta/ankaflow) - YAML-based data pipeline framework that runs both locally and fully in-browser designed for data engineers, ML teams, and SaaS developers who need flexible, SQL-powered pipelines.
 - [KoliLang](https://editor.kolistat.com) - A SAS language engine (DATA step, macros, PROCs) that translates programs to DuckDB SQL — runs natively or fully in the browser on DuckDB-Wasm.
 - [DataCharter](https://github.com/datacharter/datacharter) - Local, contract-governed data explorer. Federates files and databases (Postgres, Snowflake, BigQuery, Excel, and more) through DuckDB — SQL editor, charts, profiling — then hands AI agents a PII-masked, read-only query surface over MCP. Apache-2.0.
+- [Pondview](https://github.com/paulmupeters/pondview-bi) - Open-source, DuckDB-powered BI workspace for AI-assisted analysis, SQL, charts, and dashboards.
 
 ## Backends
 


### PR DESCRIPTION
## What changed

- Added Pondview to the **Tools Powered by DuckDB** section.
- Linked to the open-source repository and summarized its AI-assisted analysis, SQL, charting, and dashboard capabilities.

## Why

Pondview is a DuckDB-powered BI workspace and is relevant to readers looking for analytics and dashboard tooling built on DuckDB.

## Impact

Awesome DuckDB readers can now discover Pondview from the curated tools list.

## Validation

- `git diff --check`
- `npx --yes awesome-lint` (the repository currently reports pre-existing duplicate-link and formatting errors; the new Pondview entry introduces no reported finding)