### PR TITLE
Add Layerbase to Client-Server Setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [pg_lake](https://github.com/snowflake-labs/pg_lake) - `pg_lake` integrates Iceberg and data lake files into Postgres. Uses DuckDB to execute queries.
 - [AliSQL](https://github.com/alibaba/AliSQL) - A MySQL branch originated from Alibaba Group. Integrates DuckDB as a native storage engine.
 - [rawquery](https://rawquery.dev) - Managed analytical platform pairing DuckDB compute with Iceberg storage on S3. Postgres wire protocol, CLI, and Python API.
+- [Layerbase](https://layerbase.com) - Managed DuckDB hosting with a browser query console, REST API and CLI, alongside 17 other database engines under one account. Databases scale to zero when idle and wake on connect.
 
 ## Extensions
 


### PR DESCRIPTION
Adds Layerbase to the Client-Server Setups section.

**Disclosure:** I am the founder of Layerbase, so this is a self-submission.

Layerbase offers managed DuckDB hosting: you create a DuckDB instance from a dashboard, CLI, or REST API and query it from a browser console, without running your own server. Databases scale to zero when idle and wake on connect. DuckDB is available on the free tier, which needs no credit card.

- Product: https://layerbase.com
- Pricing: https://layerbase.com/pricing

This fits alongside the existing managed entries in this section (Crunchy Data Warehouse, MotherDuck, rawquery). Appended at the end of the section to match how recent entries were added. Link verified working.