### PR TITLE
Add GeoSQL to Tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨
 ## Tutorials
 
 - [DBQuacks](https://dbquacks.com/tutorial/1) - An interactive SQL tutorial powered by DuckDB.
+- [GeoSQL](https://geosql.dev) - Interactive spatial SQL problems powered by DuckDB-WASM, running entirely in the browser.
 
 ## Media
 


### PR DESCRIPTION
Adds GeoSQL, a free set of 29 spatial SQL exercises that run client-side using
DuckDB-WASM with the spatial extension — point-in-polygon, spatial joins, buffers,
ST_Transform, H3 hexbinning, and queries over real Parquet datasets.

No install, no signup, no server. Source is open (MIT for the code, CC BY-SA for the problems):
https://github.com/RobertIlyes02/LearnSpatialSQL

Happy to adjust the wording or move it to a different section.