### PR TITLE
Add Bruin and ingestr to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [DuckDB VBA](https://github.com/EtienneLenoir/duckdb-vba) - Excel/VBA integration for DuckDB using the native C API through a lightweight DLL bridge. Supports Range/Array ingestion, dictionary lookups, Parquet/CSV/JSON workflows, SQLite/PostgreSQL connectivity, and Access-to-DuckDB migration.
 - [OrionBelt Semantic Layer](https://github.com/ralfbecher/orionbelt-semantic-layer) - Open-source semantic sidecar that compiles YAML semantic models to optimized SQL across 8 engines including DuckDB. Ships with an `ob-duckdb` driver, REST + Arrow Flight SQL + Postgres wire surfaces, and a baked-in DuckDB quickstart on Colab.
 - [DuckDBExcelAddin](https://github.com/sonhn85/DuckDBExcelAddin) - Native Excel XLL add-in for DuckDB with parameter binding, async execution and Excel range table functions.
+- [Bruin](https://github.com/bruin-data/bruin) - Data pipeline CLI that runs SQL and Python transformations with built-in quality checks, using DuckDB as one of its supported platforms.
+- [ingestr](https://github.com/bruin-data/ingestr) - CLI tool to copy data between databases and SaaS sources, with DuckDB supported as both a source and a destination.
 
 ## Client-Server Setups
 


### PR DESCRIPTION
Adds two DuckDB integrations to the **Integrations** section, appended to the bottom of the list per CONTRIBUTING.

- **[Bruin](https://github.com/bruin-data/bruin)** — Apache-2.0 Go CLI for data pipelines. DuckDB is a supported platform for SQL/Python transformations and quality checks ([`pkg/duckdb`](https://github.com/bruin-data/bruin/tree/main/pkg/duckdb), [docs](https://getbruin.com/docs/bruin/platforms/duckdb.html)).
- **[ingestr](https://github.com/bruin-data/ingestr)** — CLI for copying data between systems. DuckDB is supported as both source and destination ([docs](https://getbruin.com/docs/ingestr/supported-sources/duckdb.html)).

Checklist against CONTRIBUTING:
- Neither project is already listed.
- Both entries appended to the bottom of the section, no repositioning of existing entries.
- Canonical repository URLs; both resolve without authentication.
- Format matches surrounding entries; descriptions state what each tool does and its relation to DuckDB.

Disclosure: I work on Bruin, so this is a self-submission.