### PR TITLE
Add dlt-dbt-duckdb-evidence to Projects Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [msgvault](https://github.com/wesm/msgvault) - Archive a lifetime of email and chat. Offline search, analytics, and AI query over your full message history. Powered by DuckDB.
 - [datagenerator2](https://github.com/uwegeercken/datagenerator2) - Generates random data, allowing to define dependencies between individual fields and varying/definable distribution of field values.
 - [Overture Places UA](https://github.com/xtrustinfo/overture-places-ua) - Extract all Ukrainian POIs from Overture Maps releases into CSV or Parquet with a single DuckDB query.
+- [dlt-dbt-duckdb-evidence](https://github.com/Ddscully/dlt-dbt-duckdb-evidence) - End-to-end pipeline over seven public data sources in a single DuckDB file, using dlt, dbt, Polars, Dagster and Evidence. Rebuilds from live sources on every push and publishes the DuckDB file and per-table Parquet monthly.
 
 ## Integrations
 


### PR DESCRIPTION
Adds one entry to the bottom of **Projects Powered by DuckDB**.

An end-to-end pipeline over seven public data sources (Our World in Data, World
Bank WDI, Eurostat, the ECB, a CBAM regulatory annex and UCI Online Retail II),
built entirely around a single DuckDB file:

- **dlt** loads each source into a `raw` schema in the DuckDB file.
- **dbt** (via `dbt-duckdb`) builds staging views and marts in the same file.
- **Polars** handles the heavier transforms, reading and writing through DuckDB.
- **Evidence** serves the dashboard by querying that file directly.
- **Dagster** runs the whole thing as one asset graph.
- The archive layer writes the warehouse back out as hive-partitioned Parquet
  using `COPY ... PARTITION_BY`, and the monthly release ships the DuckDB file
  itself (via `COPY FROM DATABASE`) alongside per-table Parquet.

There is no cloud warehouse and no credentials anywhere in it, which is the
reason DuckDB is doing all of the work rather than being one component of it.

Live dashboard: https://ddscully.github.io/dlt-dbt-duckdb-evidence/

Checked before opening:

- Not already listed.
- Canonical repository URL, reachable without authentication (verified 200).
- Appended to the bottom of the section, per CONTRIBUTING.md.
- `node .github/scripts/check-readme-order.mjs` passes locally against `main`.
- One file changed, one line inserted, no unrelated Markdown changes.

Disclosure: this is my own project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)