### PR TITLE
Add DuckDB in Production blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨
 - [SwanLake](https://www.wangfenjin.com/posts/swanlake-en/) - An Arrow Flight SQL Datalake Service Built on DuckDB + DuckLake
 - [DuckDB-Wasm on a Plain Static Host — Without Breaking AdSense](https://csvtodashboard.com/duckdb-wasm-static-host) - Why a static site ships the single-threaded build: SharedArrayBuffer, COOP/COEP, and the cross-origin isolation tradeoff.
 - [Building duckdb-pst](https://intellekt.fyi/2026/02/03/the-data-warehouse-in-your-email-archive-teaching-duckdb-to-speak-outlook/) - How to go from 0 to a production-ready DuckDB extension for Outlook PSTs, including table functions, MAPI schema serialization, projection/statistics pushdown, concurrent planning, and late materialization.
+- [DuckDB in Production: What It's Actually Good At (and What It Isn't)](https://hikmahtechnologies.com/blog/duckdb-in-production-what-its-good-at/) - Where DuckDB fits in production and where it does not: three deployment patterns (in-process in a service, containerised batch job, Parquet lake with read-only readers), plus its limitations around single-process writes, governance and memory spill.
 
 ### Books
 


### PR DESCRIPTION
Adds one entry to **Media → Blog Posts**.

**Affiliation disclosure:** I wrote this post. Flagging it per the contributing guidelines.

- [DuckDB in Production: What It's Actually Good At (and What It Isn't)](https://hikmahtechnologies.com/blog/duckdb-in-production-what-its-good-at/)

It covers where DuckDB fits in production and where it doesn't, from systems I run: the three deployment patterns that hold up (in-process inside a service, containerised batch job, and a Parquet lake with many read-only readers), and its limitations around single-process writes, the absence of a governance layer, and memory and spill behaviour.

Checklist against the guidelines:

- Not already listed.
- Appended to the bottom of the Blog Posts list, no existing entries moved or reordered.
- Canonical URL, factual description, no promotional claims.
- Single-entry PR.
