### PR TITLE
Add 1bench to SQL clients and IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Tad](https://www.tadviewer.com) - A fast, free, cross-platform tabular data viewer application powered by DuckDB.
 - [Mongrel](https://www.visorcraft.com/duckdb) - Paid desktop database workbench with DuckDB support, including isolated transactions, transactional migrations, physical backups, and remote import from Parquet and CSV.
 - [DuckDB Lens](https://plugins.jetbrains.com/plugin/33853-duckdb-lens-duckdb-database-file-viewer) - Read-only DuckDB database file viewer for JetBrains IDEs: schema tree, paged tables of any size, constant memory. Sibling Lens viewers cover SQLite, Parquet, Excel and Jupyter files.
+- [1bench](https://1bench.dev/duckdb) - Paid cross-platform desktop client supporting DuckDB alongside two dozen other databases, including relational, document, key-value, vector and search engines.
 
 ## Projects Powered by DuckDB
 


### PR DESCRIPTION
Adds 1bench to the **SQL Clients and IDE that Support DuckDB** section, appended to the bottom per CONTRIBUTING.

1bench is a paid cross-platform desktop client (Windows, macOS, Linux) that connects to DuckDB alongside two dozen other databases, so a DuckDB file can sit next to Postgres, ClickHouse or a vector store in the same app.

Disclosure: it is our product.
