### PR TITLE
Add LibreDB Studio to SQL clients and IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Mongrel](https://www.visorcraft.com/duckdb) - Paid desktop database workbench with DuckDB support, including isolated transactions, transactional migrations, physical backups, and remote import from Parquet and CSV.
 - [DuckDB Lens](https://plugins.jetbrains.com/plugin/33853-duckdb-lens-duckdb-database-file-viewer) - Read-only DuckDB database file viewer for JetBrains IDEs: schema tree, paged tables of any size, constant memory. Sibling Lens viewers cover SQLite, Parquet, Excel and Jupyter files.
 - [1bench](https://1bench.dev/duckdb) - Paid cross-platform desktop client supporting DuckDB alongside two dozen other databases, including relational, document, key-value, vector and search engines.
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - Browser-based SQL IDE that opens DuckDB database files alongside PostgreSQL, MySQL, ClickHouse and other engines, with a schema explorer and JSON EXPLAIN plans. MIT licensed, runs as a container or Helm chart.
 
 ## Projects Powered by DuckDB
 


### PR DESCRIPTION
Adds LibreDB Studio to "SQL Clients and IDE that Support DuckDB", appended at the end of the list per CONTRIBUTING.

Affiliation: I maintain the project.

What it does with DuckDB: the connection is a path to a DuckDB database file on the server (or `:memory:`), the schema explorer reads tables and columns, and the Explain panel renders `EXPLAIN (FORMAT JSON)` output. The same browser tab also connects to PostgreSQL, MySQL, ClickHouse and other engines. MIT licensed; runs as a container or Helm chart. Provider notes: https://github.com/libredb/libredb-studio/blob/main/docs/providers/duckdb.md

Checked: URL works without authentication; the diff is one line; no existing entries were moved.