### PR TITLE
Add DBConvert Parquet Viewer to Web Clients (WebAssembly)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [csvtodashboard](https://csvtodashboard.com/csv-sql-query) - Free SQL-on-CSV in the browser via DuckDB-Wasm — no signup, no upload, files stay on-device.
 - [ParquetKit](https://parquetkit.com) - Browser-based Parquet viewer, SQL workbench and converter powered by DuckDB-Wasm. Fully client-side — files never leave your device.
 - [Bedevere](https://bedeverewise.app) - Tabular data visualizer and DuckDB SQL editor on DuckDB-Wasm: open CSV/Parquet/JSON/Arrow locally, chart results with a grammar-of-graphics `VISUALIZE` syntax, and embed it anywhere via npm component or a one-line iframe.
+- [DBConvert Parquet Viewer](https://streams.dbconvert.com/parquet-viewer) - Browser-based Parquet viewer on DuckDB-Wasm. Reads the schema, row groups, compression codecs and column statistics, runs read-only SQL over the file and exports results as CSV. A [JSONL/NDJSON viewer](https://streams.dbconvert.com/jsonl-viewer) uses the same engine. Files are opened through a browser file handle and are not uploaded.
 
 ## SQL Clients and IDE that Support DuckDB
 


### PR DESCRIPTION
Adds a browser-based Parquet viewer built on DuckDB-Wasm to the `Web Clients (WebAssembly)` section, appended at the bottom per CONTRIBUTING.

**Disclosure:** I work on DBConvert, so this is my own project.

**On the existing entry:** DBConvert Streams is already listed under `Tools Powered by DuckDB` (the self-hosted platform, added in #298). This is a different surface — a standalone page that opens a local Parquet file in the browser, with no account and nothing installed — which is why it fits with the other WebAssembly clients rather than inside that entry. Happy to withdraw if you would rather keep one entry per vendor.

What it does: reads the schema, row groups, compression codecs and column statistics, runs read-only SQL over the file (DuckDB `read_parquet`), and exports results as CSV. The file is registered as a browser file handle and is never uploaded. A JSONL/NDJSON viewer on the same engine is linked from the same entry.

Both URLs work without authentication.
