### PR TITLE
💚 Remove broken extension downloads link

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,6 @@ Community-contributed DuckDB extensions, which can be installed via `INSTALL ⟨
 ### Extension Statistics
 
 - [DuckDB Extension Radar](https://github.com/mehd-io/duckdb-extension-radar) - Repository that contains DuckDB extensions on GitHub. Refreshed daily.
-- [DuckDB extension weekly downloads](https://duckdb-ce-analysis.evidence.app/) - Statistics of weekly downloads for core extensions and community extensions. Refreshed daily.
 
 ## Tutorials
 


### PR DESCRIPTION
Remove the DuckDB extension weekly downloads entry because its hostname no longer resolves, causing LinkChecker to fail as reported in https://github.com/davidgasquez/awesome-duckdb/pull/341#issuecomment-5562498698.

Checked the one-line deletion with `git diff --check` and the README entry-order script; both passed.
