### PR TITLE
Add Vane to Libraries Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [Unleasharp.DB.DuckDB](https://github.com/TraberSoftware/Unleasharp.DB.DuckDB) - Lightweight DuckDB query-building client for C#.
 - [Snowflake Emulator](https://github.com/nnnkkk7/snowflake-emulator) - A lightweight Snowflake emulator built with Go and DuckDB for local development and testing.
 - [DuckDB.EFCoreProvider](https://github.com/skuirrels/DuckDB.EFCoreProvider) - Entity Framework Core provider for DuckDB and DuckLake, with LINQ, writes, migrations, bulk ingestion, and Parquet-backed tiered storage for .NET.
+- [Vane](https://github.com/AstroVela/vane) - A multimodal-native engine for AI workloads, built on a DuckDB fork with Python and SQL interfaces.
 
 ## DuckDB Clients and UIs
 


### PR DESCRIPTION
Vane is currently missing from the list. This PR adds it under Libraries Powered by DuckDB, describing its DuckDB foundation and Python/SQL interfaces for multimodal AI workloads.

Disclosure: I contribute to Vane.

Validation: entry-order, whitespace, and Lychee link checks passed.