### PR TITLE
Add Totsum Data Explorer to Tools Powered by DuckDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ The DuckLake file format was released on 2025-05-27: see the [website](https://d
 - [DataCharter](https://github.com/datacharter/datacharter) - Local, contract-governed data explorer. Federates files and databases (Postgres, Snowflake, BigQuery, Excel, and more) through DuckDB — SQL editor, charts, profiling — then hands AI agents a PII-masked, read-only query surface over MCP. Apache-2.0.
 - [Pondview](https://github.com/paulmupeters/pondview-bi) - Open-source, DuckDB-powered BI workspace for AI-assisted analysis, SQL, charts, and dashboards.
 - [Varan](https://varan.cloud) - Desktop SQL client that runs one query across PostgreSQL, MySQL, DuckDB and CSV/Excel files, allowing multi-source JOINs and data versioning powered by a local-first DuckDB engine.
+- [Totsum Data Explorer](https://www.totsum.app) - Desktop app (Windows, macOS) for a first look at CSV, Excel, JSON and Parquet files: plain-language questions are turned into DuckDB SQL by a language model that runs on the user's own machine. Can work on a computer with no network connection.
+
 
 ## Backends
 


### PR DESCRIPTION
Adds Totsum Data Explorer, a desktop app built on DuckDB. Disclosure: I am the developer (Totsum SRL). Description kept factual per CONTRIBUTING; URL is public, no authentication.